### PR TITLE
Handle missing AI configuration to avoid silent Telegram failures

### DIFF
--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,24 +1,23 @@
 import { createOpenAI } from "@ai-sdk/openai";
 
 const embeddingApiKey = Bun.env.OPENAI_API_KEY ?? Bun.env.ANANNAS_API_KEY;
-const embeddingBaseUrl = Bun.env.OPENAI_EMBEDDING_BASE_URL ?? Bun.env.OPENAI_BASE_URL;
+const embeddingBaseUrl =
+  Bun.env.OPENAI_EMBEDDING_BASE_URL ?? Bun.env.OPENAI_BASE_URL;
+const hasEmbeddingConfig = Boolean(embeddingApiKey && embeddingBaseUrl);
 
-if (!embeddingApiKey) {
-  throw new Error("OPENAI_API_KEY or ANANNAS_API_KEY is required for embeddings.");
-}
-
-if (!embeddingBaseUrl) {
-  throw new Error("OPENAI_EMBEDDING_BASE_URL or OPENAI_BASE_URL is required for embeddings.");
-}
-
-const embeddingsClient = createOpenAI({
-  apiKey: embeddingApiKey,
-  baseURL: embeddingBaseUrl,
-});
+const embeddingsClient = hasEmbeddingConfig
+  ? createOpenAI({
+      apiKey: embeddingApiKey as string,
+      baseURL: embeddingBaseUrl as string,
+    })
+  : null;
 
 export async function embedText(input: string): Promise<number[]> {
   const normalized = input.trim().slice(0, 2000);
   if (!normalized) return [];
+  if (!embeddingsClient) {
+    return [];
+  }
 
   try {
     const { embeddings } = await embeddingsClient.embeddings.create({

--- a/src/server.ts
+++ b/src/server.ts
@@ -259,13 +259,23 @@ const app = new Elysia()
         console.warn("Falling back to remote image URL for processing.");
       }
 
-      const result = await askAI(
-        message || "What's in this image?",
-        userId,
-        userTimezone,
-        todoistToken,
-        imageDataUrl ?? imageUrl,
-      );
+      let result;
+      try {
+        result = await askAI(
+          message || "What's in this image?",
+          userId,
+          userTimezone,
+          todoistToken,
+          imageDataUrl ?? imageUrl,
+        );
+      } catch (error) {
+        console.error("AI request failed:", error);
+        set.status = 500;
+        return {
+          reply:
+            "Sorry, I'm having trouble responding right now. Please try again in a moment.",
+        };
+      }
       
       if (result.todoist) {
         return { reply: result.todoist };


### PR DESCRIPTION
### Motivation
- Prevent the bot from failing silently when core AI or embedding environment variables are missing so Telegram messages still receive a useful reply.
- Make embeddings optional so the service can start without embedding configuration and memory features degrade gracefully.
- Ensure unexpected AI runtime errors during `/ask` return a friendly error response instead of causing request failures.

### Description
- Guard AI client initialization in `src/ai.ts` so `ANANNAS_API_KEY` and `OPENAI_BASE_URL` are optional and `askAI` returns a clear configuration message when the text model is not available.
- Short-circuit `detectReminderIntent` to return `null` when the text model is unavailable to avoid calling the LLM in that case.
- Make the embeddings client optional in `src/embeddings.ts` and return an empty embedding when embedding configuration is absent so memory/embedding flows simply skip.
- Wrap the `askAI` call in `src/server.ts` with a `try/catch` and return a 500-friendly reply (`Sorry, I'm having trouble responding right now...`) when AI requests fail.

### Testing
- No automated tests were run as part of this change (`not run`).
- Manual validation recommended: start the server without `ANANNAS_API_KEY`/`OPENAI_BASE_URL` and confirm the bot responds with the configuration message instead of timing out.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d98530dc832da66c1ebf970f6d6f)