### PR TITLE
Fix embedding integration & guard fallback memory search

### DIFF
--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,31 +1,35 @@
 import { createOpenAI } from "@ai-sdk/openai";
+import { embed } from "ai";
 
 const embeddingApiKey = Bun.env.OPENAI_API_KEY ?? Bun.env.ANANNAS_API_KEY;
 const embeddingBaseUrl =
   Bun.env.OPENAI_EMBEDDING_BASE_URL ?? Bun.env.OPENAI_BASE_URL;
 const hasEmbeddingConfig = Boolean(embeddingApiKey && embeddingBaseUrl);
 
-const embeddingsClient = hasEmbeddingConfig
+const openai = hasEmbeddingConfig
   ? createOpenAI({
       apiKey: embeddingApiKey as string,
       baseURL: embeddingBaseUrl as string,
     })
   : null;
+const embeddingModel = openai?.embedding(
+  Bun.env.OPENAI_EMBEDDING_MODEL ?? "text-embedding-3-small",
+);
 
 export async function embedText(input: string): Promise<number[]> {
   const normalized = input.trim().slice(0, 2000);
   if (!normalized) return [];
-  if (!embeddingsClient) {
+  if (!embeddingModel) {
     return [];
   }
 
   try {
-    const { embeddings } = await embeddingsClient.embeddings.create({
-      model: Bun.env.OPENAI_EMBEDDING_MODEL ?? "text-embedding-3-small",
-      input: normalized,
+    const { embedding } = await embed({
+      model: embeddingModel,
+      value: normalized,
     });
 
-    return embeddings[0]?.embedding ?? [];
+    return embedding ?? [];
   } catch (error) {
     console.error("Embedding error:", error);
     return [];

--- a/src/memory-repo.ts
+++ b/src/memory-repo.ts
@@ -118,14 +118,19 @@ async function fallbackSearchMemories(params: {
         )
       : and(eq(userMemories.userId, params.userId), contentFilter);
 
-  const rows = await db
-    .select()
-    .from(userMemories)
-    .where(whereClause)
-    .orderBy(desc(userMemories.importance), desc(userMemories.updatedAt))
-    .limit(params.topK ?? 8);
+  try {
+    const rows = await db
+      .select()
+      .from(userMemories)
+      .where(whereClause)
+      .orderBy(desc(userMemories.importance), desc(userMemories.updatedAt))
+      .limit(params.topK ?? 8);
 
-  return rows;
+    return rows;
+  } catch (error) {
+    console.error("Failed to run fallback memory search:", error);
+    return [];
+  }
 }
 
 export async function touchMemories(ids: number[]): Promise<void> {


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes when the OpenAI embeddings client is not available and when fallback DB searches encounter missing tables or other query errors.
- Replace direct provider client calls with the SDK `embed` helper to use the configured embedding model consistently and reduce undefined-object errors.

### Description
- Replace direct `embeddingsClient.embeddings.create` usage with `embed({ model, value })` and derive an `embeddingModel` from the configured OpenAI provider in `src/embeddings.ts`.
- Guard the embedding path by returning early if no embedding model is configured to avoid TypeError crashes.
- Wrap the fallback memory search DB query in a `try/catch` in `src/memory-repo.ts` to log failures and return an empty array instead of bubbling SQL errors.
- Preserve existing behavior of falling back to text-based search when embeddings are unavailable or return empty results.

### Testing
- No automated tests were run as part of this change (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981dbfda70c832d9e84acac857eb4ed)