### PR TITLE
Add Telegram update deduping guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ Start the scheduler (in a separate terminal):
 bun run src/scheduler.ts
 ```
 
+### Telegram bot mode
+
+Use **one** bot mode at a time:
+
+- **Webhook mode** (recommended for production): configure Telegram to send updates to `/webhook` on your API server.
+- **Polling mode** (local/dev): run `bun run src/bot-polling.ts`.
+
+Running multiple polling processes (or multiple bot instances with the same token) can cause duplicate replies because each process receives the same update.
+
 ## Usage
 
 ### Setting Reminders

--- a/src/bot-polling.ts
+++ b/src/bot-polling.ts
@@ -1,4 +1,5 @@
 import { Bot } from "grammy";
+import { createUpdateDeduper } from "./telegram-dedupe.js";
 
 const token = Bun.env.BOT_TOKEN;
 if (!token) {
@@ -7,6 +8,12 @@ if (!token) {
 
 const apiBaseUrl = Bun.env.API_BASE_URL || "http://localhost:3000";
 const bot = new Bot(token);
+const isDuplicateUpdate = createUpdateDeduper();
+
+bot.use((ctx, next) => {
+  if (isDuplicateUpdate(ctx.update.update_id)) return;
+  return next();
+});
 
 bot.on("message:text", async (ctx) => {
   const message = ctx.message.text.trim();

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,4 +1,5 @@
 import { Bot, webhookCallback } from "grammy";
+import { createUpdateDeduper } from "./telegram-dedupe.js";
 
 const apiBaseUrl = Bun.env.API_BASE_URL || "http://localhost:3000";
 
@@ -13,6 +14,12 @@ export function getWebhookHandler() {
   }
 
   const bot = new Bot(token);
+  const isDuplicateUpdate = createUpdateDeduper();
+
+  bot.use((ctx, next) => {
+    if (isDuplicateUpdate(ctx.update.update_id)) return;
+    return next();
+  });
 
   bot.command("start", async (ctx) => {
     const webAppUrl = `${apiBaseUrl}/app`;

--- a/src/telegram-dedupe.ts
+++ b/src/telegram-dedupe.ts
@@ -1,0 +1,21 @@
+export function createUpdateDeduper(maxSize = 1000) {
+  const seen = new Set<number>();
+  const order: number[] = [];
+
+  return (updateId?: number) => {
+    if (updateId === undefined || updateId === null) return false;
+    if (seen.has(updateId)) return true;
+
+    seen.add(updateId);
+    order.push(updateId);
+
+    if (order.length > maxSize) {
+      const oldest = order.shift();
+      if (oldest !== undefined) {
+        seen.delete(oldest);
+      }
+    }
+
+    return false;
+  };
+}


### PR DESCRIPTION
### Motivation

- Duplicate replies were caused when the same Telegram update was processed multiple times (e.g. webhook retries or multiple polling instances). 
- A lightweight, in-process deduper prevents handling the same `update_id` more than once across handlers.

### Description

- Add `src/telegram-dedupe.ts` which exports `createUpdateDeduper` to track recent `update_id`s and skip repeats. 
- Integrate the deduper into `src/bot.ts` (webhook handler) and `src/bot-polling.ts` (polling) by adding middleware that calls `isDuplicateUpdate(ctx.update.update_id)`. 
- Update `README.md` to document bot modes and advise running only one mode/process at a time to avoid duplicate replies.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e2a6b7d0832d940e9314309be66d)